### PR TITLE
[Improvement] Add BackToTop scroll button

### DIFF
--- a/style.css
+++ b/style.css
@@ -1082,6 +1082,16 @@ object {
     float:left;
 }
 
+/* Scroll to top button style */
+.backtotop {
+    border-radius: 15px;
+    text-align: center;
+    font-size: 27px!important;
+    overflow: hidden;
+    color: #fff !important;
+    background-color: #ef4b47;
+}
+
 /* Select TLDs option style*/
 .ant-input-affix-wrapper {
     z-index: 1;
@@ -1223,6 +1233,10 @@ object {
         max-height: 100px;
         overflow: hidden;
     }
+
+    .backtotop {
+        right: 30px !important;
+    }
 }
 
 .primary-menu .current_page_item a {
@@ -1275,6 +1289,12 @@ object {
     /* Hide tags on mobile */
     .featured-tags {
         display: none;
+    }
+
+    .backtotop {
+        right: 0 !important;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
     }
 
     /* TLDs option on mobile */


### PR DESCRIPTION
Tested in Chrome, Opera, Firefox and IE10. Working as expected.
UI for this PR: 
![backtotop-scroll-button](https://user-images.githubusercontent.com/29831471/45292748-ca170800-b4fe-11e8-80f8-0f1bb235c06e.jpg)

Issue reference: Codeinwp/domainwheel#57